### PR TITLE
Add key parameter to SettingRow stateful widget

### DIFF
--- a/lib/cupertino_setting_control.dart
+++ b/lib/cupertino_setting_control.dart
@@ -238,11 +238,12 @@ class SettingsRowStyle {
 class SettingRow extends StatefulWidget {
   /// A setting widget with multiple configuration options
   const SettingRow(
-      {this.rowData,
+      {Key key,
+      this.rowData,
       this.onSettingDataRowChange,
       this.config = const SettingsRowConfiguration(),
       this.style = const SettingsRowStyle(),
-      this.enabled = true});
+      this.enabled = true}): super(key: key);
 
   /// Defines the type of the setting row widget. E.g. a drop down, text field etc.
   final SettingRowConfig rowData;


### PR DESCRIPTION
Please add key parameter to SettingRow stateful widget, the reason being if you have a stateful widget as parent, you will found setState() won't rebuild the rows.